### PR TITLE
Modified subject to include a date string.

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -10,6 +10,10 @@ module.exports = (function() {
 		this.client = require('nodemailer').mail;
 	};
 
+	Email.getSubjectDate = function() {
+		return new Date().toLocaleDateString();
+	};
+
 	Email.prototype.setClient = function(client) {
 		this.client = client;
 	};
@@ -18,7 +22,7 @@ module.exports = (function() {
 		this.client({
 			from: this.replyTo,
 			to: this.emailAddresses,
-			subject: 'Drill Sergeant Stale Pull Request Report',
+			subject: 'Drill Sergeant Stale Pull Request Report (' + Email.getSubjectDate() + ')',
 			html: this.compiledTemplate({ repos: repos })
 		});
 	};

--- a/test/spec/email.spec.js
+++ b/test/spec/email.spec.js
@@ -9,11 +9,15 @@ describe('Email lib', function() {
 			expect(options).toEqual({
 				from: 'test-from@test.com',
 				to: 'test@test.com',
-				subject: 'Drill Sergeant Stale Pull Request Report',
+				subject: 'Drill Sergeant Stale Pull Request Report (2013/12/01)',
   				html: '<h1>Drill Sergeant</h1>\n<h2>Stale Pull Request Report</h2>\n\n\n\t<h4>zumba/repository</h4>\n\t<ul>\n\t\n\t\t<li><a href="https://github/zumba/repository/pull/19">Some pull request</a></li>\n\t\n\t</ul>\n\n'
 			});
 		};
 		mail.setClient(clientMock);
+		// Mock the date on the subject
+		email.getSubjectDate = function() {
+			return '2013/12/01';
+		}
 		mail.notify([
 			{
 				repo: 'zumba/repository',


### PR DESCRIPTION
This will prevent gmail and other email clients that group emails by subject from collapsing the body of the email notification.
