### PR TITLE
Escape the stale PR title in html email notification

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -1,5 +1,5 @@
 var Github = require('github'),
-	_ = require('underscore');
+	_ = require('lodash');
 
 /**
  * @scope Client

--- a/lib/notifiers/email.js
+++ b/lib/notifiers/email.js
@@ -19,6 +19,12 @@ module.exports = (function() {
 	};
 
 	Email.prototype.notify = function(repos) {
+		_.forEach(repos, function(repo) {
+			repo.prs = _.map(repo.prs, function(pr) {
+				pr.title = _.escape(pr.title);
+				return pr;
+			});
+		});
 		this.client({
 			from: this.replyTo,
 			to: this.emailAddresses,

--- a/lib/notifiers/email.js
+++ b/lib/notifiers/email.js
@@ -1,4 +1,4 @@
-var _ = require('underscore'),
+var _ = require('lodash'),
 	fs = require('fs');
 
 module.exports = (function() {

--- a/lib/notifiers/github.js
+++ b/lib/notifiers/github.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var async = require('async');
 
 module.exports = (function() {

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var async = require('async');
 
 module.exports = (function() {

--- a/lib/stalerepos.js
+++ b/lib/stalerepos.js
@@ -1,4 +1,4 @@
-var _ = require('underscore'),
+var _ = require('lodash'),
 	async = require('async');
 
 var stalerepos = module.exports = {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "url": "https://github.com/zumba/drill-sergeant/issues"
   },
   "dependencies": {
-    "github": "0.1.*",
-    "nodemailer": "0.5.*",
-    "commander": "2.1.*",
     "async": "0.2.*",
-    "underscore": "1.5.*"
+    "commander": "2.1.*",
+    "github": "0.1.*",
+    "lodash": "^3.10.1",
+    "nodemailer": "0.5.*"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/templates/email.html
+++ b/templates/email.html
@@ -4,8 +4,6 @@
 <% _.each(repos, function(repo) { %>
 	<h4><%= repo.repo %></h4>
 	<ul>
-	<% _.each(repo.prs, function(pr) { %>
-		<li><a href="<%= pr.html_url %>"><%= pr.title %></a> [<%= pr.user %>]</li>
-	<% }); %>
+		<% _.each(repo.prs, function(pr) { %><li><a href="<%= pr.html_url %>"><%= pr.title %></a> [<%= pr.user %>]</li><% }); %>
 	</ul>
 <% }); %>

--- a/test/spec/notifiers/email.spec.js
+++ b/test/spec/notifiers/email.spec.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var email = require('../../../lib/notifiers/email');
-var _ = require('underscore');
+var _ = require('lodash');
 
 describe('Email lib', function() {
 	it('will email a notification with stale repos', function() {

--- a/test/spec/notifiers/email.spec.js
+++ b/test/spec/notifiers/email.spec.js
@@ -14,7 +14,7 @@ describe('Email lib', function() {
 				prs: [{
 					created_at: new Date().toISOString(),
 					html_url: 'https://github/zumba/repository/pull/19',
-					title: 'Some pull request',
+					title: 'Some <b>awesome</b> pull request',
 					user: 'someuser'
 				}]
 			}
@@ -26,6 +26,7 @@ describe('Email lib', function() {
 				subject: 'Drill Sergeant Stale Pull Request Report (2013/12/01)',
 				html: template({repos: repos})
 			});
+			expect(_.trim(options.html)).toEqual(_.trim(fs.readFileSync(__dirname + '/email_output.html').toString()));
 		};
 		mail.setClient(clientMock);
 		// Mock the date on the subject

--- a/test/spec/notifiers/email_output.html
+++ b/test/spec/notifiers/email_output.html
@@ -1,0 +1,8 @@
+<h1>Drill Sergeant</h1>
+<h2>Stale Pull Request Report</h2>
+
+
+	<h4>zumba/repository</h4>
+	<ul>
+		<li><a href="https://github/zumba/repository/pull/19">Some &lt;b&gt;awesome&lt;/b&gt; pull request</a> [someuser]</li>
+	</ul>


### PR DESCRIPTION
This PR escapes email notifications from stale PR titles. Since the title is freeform text from the user, it can be used to inject malicious things into an email client not equipped to handle.

Closes #10. 