### PR TITLE
Allow filtering by label (including/excluding).

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var command = require('commander'),
 	stalerepos = require('./lib/stalerepos'),
 	notifiers = {
 		email: require('./lib/notifiers/email'),
-		github: require('./lib/notifiers/github')
+		github: require('./lib/notifiers/github'),
+		console: require('./lib/notifiers/console')
 	},
 	notify = require('./lib/notify');
 
@@ -35,11 +36,6 @@ if (!command.repo.length) {
 	process.exit(1);
 }
 
-if (!command.email && !command.label) {
-	console.error('Email or label argument must be provided.');
-	process.exit(1);
-}
-
 ghClient = new github(process.env.GITHUB_TOKEN);
 notifier = new notify();
 
@@ -54,6 +50,9 @@ stalerepos.retrieve(command.repo, ghClient, command.staletime)
 		}
 		if (command.label) {
 			notifier.add(new notifiers.github(ghClient));
+		}
+		if (!command.email && !command.label) {
+			notifier.add(notifiers.console);
 		}
 		notifier.notifyAll(results);
 	});

--- a/index.js
+++ b/index.js
@@ -12,9 +12,13 @@ var ghClient, repos, mail;
 
 process.title = 'drillsergeant';
 
+var coerceList = function(input) {
+	return input.split(',');
+};
+
 command
 	.version(pkg.version)
-	.option('-r, --repo [user/repository]', 'Define the [comma delimited] repositories to check PRs.')
+	.option('-r, --repo <user/repository>', 'Define the [comma delimited] repositories to check PRs.', coerceList, [])
 	.option('-e, --email [email@address]', 'Set the [comma delimited] email address(es) to be notified.', null)
 	.option('-f, --replyto [Notifier Title <email@address>]', 'Set the reply to email address.', 'Drill Sergeant Notifier <no-reply@drillsergeant>')
 	.option('-l, --label', 'Should drill sergeant label the PR as stale?', false)
@@ -26,7 +30,7 @@ if (!process.env.GITHUB_TOKEN) {
 	process.exit(1);
 }
 
-if (!command.repo) {
+if (!command.repo.length) {
 	console.error('Repo argument must be provided.');
 	process.exit(1);
 }
@@ -36,12 +40,10 @@ if (!command.email && !command.label) {
 	process.exit(1);
 }
 
-repos = command.repo.split(',');
-
 ghClient = new github(process.env.GITHUB_TOKEN);
 notifier = new notify();
 
-stalerepos.retrieve(repos, ghClient, command.staletime)
+stalerepos.retrieve(command.repo, ghClient, command.staletime)
 	.then(function(results) {
 		if (!results.length) {
 			console.log('No stale pull requests to report.');

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ stalerepos.retrieve(command.repo, ghClient, command.staletime)
 			return;
 		}
 		if (command.email) {
-			notifier.add(new notifiers.email(command.email, command.replyto, ghClient));
+			notifier.add(new notifiers.email(command.email, command.replyto));
 		}
 		if (command.label) {
 			notifier.add(new notifiers.github(ghClient));

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -5,7 +5,7 @@ module.exports = {
 			return repo;
 		}
 		repo.prs = repo.prs.filter(function(pr) {
-			return pr.labels.length > _.difference(pr.labels, labels).length
+			return pr.labels.length > _.difference(pr.labels, labels).length;
 		});
 		return repo;
 	},
@@ -14,7 +14,7 @@ module.exports = {
 			return repo;
 		}
 		repo.prs = repo.prs.filter(function(pr) {
-			return pr.labels.length === _.difference(pr.labels, labels).length
+			return pr.labels.length === _.difference(pr.labels, labels).length;
 		});
 		return repo;
 	}

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,0 +1,21 @@
+var _ = require('lodash');
+module.exports = {
+	includeLabels: function(labels, repo) {
+		if (!labels.length) {
+			return repo;
+		}
+		repo.prs = repo.prs.filter(function(pr) {
+			return pr.labels.length > _.difference(pr.labels, labels).length
+		});
+		return repo;
+	},
+	excludeLabels: function(labels, repo) {
+		if (!labels.length) {
+			return repo;
+		}
+		repo.prs = repo.prs.filter(function(pr) {
+			return pr.labels.length === _.difference(pr.labels, labels).length
+		});
+		return repo;
+	}
+};

--- a/lib/notifiers/console.js
+++ b/lib/notifiers/console.js
@@ -1,0 +1,12 @@
+module.exports = {
+	notify: function(repos) {
+		repos.forEach(function(repo, i) {
+			if (!i) {
+				console.log(repo.repo);
+			}
+			repo.prs.forEach(function(pr) {
+				console.log('  %s - %s', pr.title, pr.html_url);
+			});
+		});
+	}
+};

--- a/lib/notifiers/email.js
+++ b/lib/notifiers/email.js
@@ -2,13 +2,12 @@ var fs = require('fs');
 var _ = require('lodash');
 var P = require('bluebird');
 
-var Email = module.exports = function(emailAddresses, replyTo, ghClient) {
+var Email = module.exports = function(emailAddresses, replyTo) {
 	var template = fs.readFileSync(__dirname + '/../../templates/email.html').toString();
 	this.emailAddresses = emailAddresses;
 	this.replyTo = replyTo;
 	this.compiledTemplate = _.template(template);
 	this.client = require('nodemailer').mail;
-	this.ghClient = ghClient;
 };
 
 Email.getSubjectDate = function() {
@@ -19,22 +18,15 @@ Email.prototype.setClient = function(client) {
 	this.client = client;
 };
 
-var applyLabels = function(repo, pr) {
-	return this.getLabels(repo, pr.number)
-		.then(function(labels) {
-			pr.labels = labels;
-			return pr;
-		});
-};
-
 Email.prototype.notify = function(repos) {
 	var escapePrTitle = function(pr) {
 		pr.title = _.escape(pr.title);
 		return pr;
 	};
-	var mapRepoLabels = function(repo) {
-		return P.map(repo.prs, applyLabels.bind(this.ghClient, repo.repo)).map(escapePrTitle);
-	}.bind(this);
+	var mapTitles = function(repo) {
+		repo.prs = repo.prs.map(escapePrTitle);
+		return repo;
+	};
 	var sendEmail = function() {
 		return this.client({
 			from: this.replyTo,
@@ -43,5 +35,5 @@ Email.prototype.notify = function(repos) {
 			html: this.compiledTemplate({ repos: repos })
 		});
 	}.bind(this);
-	return P.map(repos, mapRepoLabels).then(sendEmail);
+	return P.map(repos, mapTitles).then(sendEmail);
 };

--- a/lib/stalerepos.js
+++ b/lib/stalerepos.js
@@ -12,9 +12,22 @@ var stalerepos = module.exports = {
 		var entries = [];
 		var prQueue = [];
 		var mapProperties = ['created_at', 'html_url', 'title', 'number', 'update_at'];
-		repos.forEach(function(repo) {
-			prQueue.push(ghClient.getPullRequests.bind(ghClient, repo, 'open'));
-		});
+		var applyLabels = function(repo, pr) {
+			return this.getLabels(repo, pr.number)
+				.then(function(labels) {
+					pr.labels = labels;
+					return pr;
+				});
+		};
+		var mapRepoLabels = function(repo) {
+			return P.map(repo.prs, applyLabels.bind(this, repo.repo))
+				.then(function(prs) {
+					return {
+						repo: repo.repo,
+						prs: prs
+					};
+				});
+		}.bind(ghClient);
 		return P.map(repos, function(repo) {
 			return ghClient.getPullRequests(repo, 'open').then(function(prs) {
 				return {
@@ -36,6 +49,6 @@ var stalerepos = module.exports = {
 						})
 				};
 			});
-		});
+		}).map(mapRepoLabels);
 	}
 };

--- a/test/spec/notifiers/email.spec.js
+++ b/test/spec/notifiers/email.spec.js
@@ -6,24 +6,8 @@ var _ = require('lodash');
 describe('Email lib', function() {
 	it('will email a notification with stale repos', function() {
 		var mail, clientMock, template, repos;
-		var ghClient = new github('token');
-		ghClient.setClient({
-			authenticate: function() {},
-			issues: {
-				getRepoIssue: function(options, callback) {
-					expect(options).to.deep.equal({
-						user: 'zumba',
-						repo: 'repository',
-						number: '19'
-					});
-					callback(null, {
-						labels: [{name: 'sometag'}]
-					});
-				}
-			}
-		});
 
-		mail = new email('test@test.com', 'test-from@test.com', ghClient);
+		mail = new email('test@test.com', 'test-from@test.com');
 		template = _.template(fs.readFileSync(__dirname + '/../../../templates/email.html').toString());
 		repos = [
 			{
@@ -33,7 +17,8 @@ describe('Email lib', function() {
 					html_url: 'https://github/zumba/repository/pull/19',
 					title: 'Some <b>awesome</b> pull request',
 					user: 'someuser',
-					number: '19'
+					number: '19',
+					labels: ['sometag']
 				}]
 			}
 		];

--- a/test/spec/stalerepos.spec.js
+++ b/test/spec/stalerepos.spec.js
@@ -28,6 +28,13 @@ describe('Stale Repo Lib', function() {
 					fixed.updated_at = target.toISOString();
 					callback(null, fixed);
 				}
+			},
+			issues: {
+				getRepoIssue: function(options, callback) {
+					callback(null, {
+						labels: []
+					});
+				}
 			}
 		};
 		gc.setClient(clientMock);
@@ -40,7 +47,8 @@ describe('Stale Repo Lib', function() {
 						"html_url": "https://github.com/zumba/repository/pull/19",
 						"number": 19,
 						"title": "Some pull request.",
-						"user": "cjsaylor"
+						"user": "cjsaylor",
+						"labels": []
 					}
 				]
 			}


### PR DESCRIPTION
This PR adds the ability (and command-line attributes) to filter PRs by labels.

For example, if you wanted to show stale PRs that have the label "Code Reviewed", you would do: `drillsergeant -r some/repo --include-labels "Code Reviewed"`. The reverse is also available with `--exclude-labels`.

The following additional changes were made:

* Labels property are available for all notifiers.
* Added a console notifier in order to see results without having to email the report.