### PR TITLE
Add support for Github Reviews.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -17,7 +17,6 @@ module.exports = function(grunt) {
     });
     grunt.loadNpmTasks('grunt-eslint');
     grunt.loadNpmTasks('grunt-mocha-test');
-    grunt.loadTasks('tasks');
 
     // Default task.
     grunt.registerTask('default', ['eslint', 'mochaTest']);

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ command
 	.option('-s, --staletime [number of hours]', 'Set the PR stale threshold. (default: 24)', 24)
 	.option('--include-labels [labels]', 'Define a [comma delimited] group of labels of which a PR must have at least one.', coerceList, [])
 	.option('--exclude-labels [labels]', 'Define a [comma delimited] group of labels of which a PR must NOT contain.', coerceList, [])
+	.option('--include-reviewed [count]', 'Filter PRs with at least [count] approved reviews.',  0)
+	.option('--exclude-reviewed [count]', 'Filter PRs without at least [count] approved reviews.',  0)
 	.parse(process.argv);
 
 if (!process.env.GITHUB_TOKEN) {
@@ -49,7 +51,9 @@ function main() {
 			const allPRs = yield stalerepos.retrieve(command.repo, command.staletime);
 			const results = allPRs
 				.filter(filters.includeLabels.bind(null, command.includeLabels))
-				.filter(filters.excludeLabels.bind(null, command.excludeLabels));
+				.filter(filters.excludeLabels.bind(null, command.excludeLabels))
+				.filter(repo => command.includeReviewed === 0 || filters.includeReviewed(command.includeReviewed, repo))
+				.filter(repo => command.excludeReviewed === 0 || filters.excludeReviewed(command.excludeReviewed, repo));
 			if (!results.length) {
 				console.log('No stale pull requests to report.');
 				return

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -7,7 +7,7 @@ module.exports = {
 		repo.prs = repo.prs.filter(function(pr) {
 			return pr.labels.length > _.difference(pr.labels, labels).length;
 		});
-		return repo;
+		return repo.prs.length > 0;
 	},
 	excludeLabels: function(labels, repo) {
 		if (!labels.length) {
@@ -16,6 +16,20 @@ module.exports = {
 		repo.prs = repo.prs.filter(function(pr) {
 			return pr.labels.length === _.difference(pr.labels, labels).length;
 		});
-		return repo;
+		return repo.prs.length > 0;
+	},
+	includeReviewed: function(count, repo) {
+		if (!count) {
+			return repo;
+		}
+		repo.prs = repo.prs.filter(pr => pr.reviewCount >= count);
+		return repo.prs.length > 0;
+	},
+	excludeReviewed: function(count, repo) {
+		if (!count) {
+			return repo;
+		}
+		repo.prs = repo.prs.filter(pr => pr.reviewCount < count);
+		return repo.prs.length > 0;
 	}
 };

--- a/lib/stalerepos.js
+++ b/lib/stalerepos.js
@@ -40,7 +40,8 @@ module.exports = class StaleRepos {
 								title: data.title,
 								number: data.number,
 								updated_at: data.updatedAt,
-								labels: data.labels.edges.map(entry => entry.node.name)
+								labels: data.labels.edges.map(entry => entry.node.name),
+								reviewCount: data.reviews.totalCount
 							};
 						})
 						.filter(pr => this.isStale(staletime, pr))

--- a/templates/repositoryQuery
+++ b/templates/repositoryQuery
@@ -15,6 +15,9 @@ fragment prEdge on PullRequestEdge {
         }
       }
     }
+    reviews(states:[APPROVED],first:1) {
+      totalCount
+    }
   }
 }
 

--- a/test/fixture/pullrequestgraph.json
+++ b/test/fixture/pullrequestgraph.json
@@ -26,6 +26,9 @@
 										}
 									}
 								]
+							},
+							"reviews": {
+								"totalCount": 1
 							}
 						}
 					}

--- a/test/fixture/pullrequestgraphquery.txt
+++ b/test/fixture/pullrequestgraphquery.txt
@@ -15,6 +15,9 @@ fragment prEdge on PullRequestEdge {
         }
       }
     }
+    reviews(states:[APPROVED],first:1) {
+      totalCount
+    }
   }
 }
 

--- a/test/spec/stalerepos.spec.js
+++ b/test/spec/stalerepos.spec.js
@@ -41,7 +41,8 @@ describe('Stale Repo Lib', function() {
 						"labels": [
 							"Code Reviewed",
 							"Stale"
-						]
+						],
+						"reviewCount": 1
 					}
 				]
 			}


### PR DESCRIPTION
This PR adds support for filtering pull requests to include or exclude PRs based on total # of approved reviews.

```bash
drillsergeant -r zumba/drill-sergeant --exclude-reviewed 1
```
> The above command will exclude any PR that has at least `1` review.

Additionally, if all PRs are filtered by labels/review-count, then it will remove the repo header from the list to display.

This PR is reliant on the graphql changes from #18.