### PR TITLE
Fix bug with repos with dashes.

### DIFF
--- a/lib/stalerepos.js
+++ b/lib/stalerepos.js
@@ -26,10 +26,9 @@ module.exports = class StaleRepos {
 		});
 		return co.call(this, function*() {
 			const response = yield this.ghClient.graph(this.queryTemplate({ repos: separatedRepos }));
-			return _.map(response.data, (prs, repo) => {
-				const [owner, ...name] = repo.split('_');
+			return _.map(response.data, (prs, key) => {
 				return {
-					repo: `${owner}/${name.join()}`,
+					repo: response.data[key].nameWithOwner,
 					prs: prs.pullRequests.edges
 						.map(pr => {
 							const data = pr.node;

--- a/templates/repositoryQuery
+++ b/templates/repositoryQuery
@@ -23,7 +23,8 @@ fragment prEdge on PullRequestEdge {
 
 query {
 <% _.each(repos, function(repo) { %>
-  <%= repo.owner + '_' + repo.name %>: repository(owner: "<%= repo.owner %>", name: "<%= repo.name %>") {
+  <%= repo.owner + _.camelCase(repo.name) %>: repository(owner: "<%= repo.owner %>", name: "<%= repo.name %>") {
+    nameWithOwner
     pullRequests(last: 100, states: [OPEN]) {
       edges {
         ...prEdge

--- a/test/fixture/pullrequestgraph.json
+++ b/test/fixture/pullrequestgraph.json
@@ -1,6 +1,7 @@
 {
 	"data": {
 		"zumba_repository": {
+			"nameWithOwner": "zumba/repository",
 			"pullRequests": {
 				"edges": [
 					{

--- a/test/fixture/pullrequestgraphquery.txt
+++ b/test/fixture/pullrequestgraphquery.txt
@@ -23,7 +23,8 @@ fragment prEdge on PullRequestEdge {
 
 query {
 
-  zumba_repository: repository(owner: "zumba", name: "repository") {
+  zumbarepository: repository(owner: "zumba", name: "repository") {
+    nameWithOwner
     pullRequests(last: 100, states: [OPEN]) {
       edges {
         ...prEdge


### PR DESCRIPTION
The graphql alias for each repo was not escaping `-` (a common allowable repo string). This PR escapes that keyname as well as removes reliance on the manipulated key to ascertain the repo `nameWithOwner` by shifting to the actual value from the graphql response.