### PR TITLE
Allow customization of the email notification subject

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,11 @@ module.exports = {
             "always"
         ],
         "no-console": OFF
+    },
+    "globals": {
+        // Testing globals
+        "describe": true,
+        "it": true,
+        "expect": true
     }
 };

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ command
 	.option('-r, --repo <user/repository>', 'Define the [comma delimited] repositories to check PRs.', coerceList, [])
 	.option('-e, --email [email@address]', 'Set the [comma delimited] email address(es) to be notified.', null)
 	.option('-f, --replyto [Notifier Title <email@address>]', 'Set the reply to email address.', 'Drill Sergeant Notifier <no-reply@drillsergeant>')
-	.option('--subject-template', 'Set the email notification subject template. (date variable available in the template.)', 'Drill Sergeant Stale Pull Request Report (<%= date %>)')
+	.option('--subject-template [Some template (<%= date %>)', 'Set the email notification subject template. (date variable available in the template.)', 'Drill Sergeant Stale Pull Request Report (<%= date %>)')
 	.option('-l, --label', 'Should drill sergeant label the PR as stale?', false)
 	.option('-s, --staletime [number of hours]', 'Set the PR stale threshold. (default: 24)', 24)
 	.option('--include-labels [labels]', 'Define a [comma delimited] group of labels of which a PR must have at least one.', coerceList, [])

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ command
 	.option('-r, --repo <user/repository>', 'Define the [comma delimited] repositories to check PRs.', coerceList, [])
 	.option('-e, --email [email@address]', 'Set the [comma delimited] email address(es) to be notified.', null)
 	.option('-f, --replyto [Notifier Title <email@address>]', 'Set the reply to email address.', 'Drill Sergeant Notifier <no-reply@drillsergeant>')
+	.option('--subject-template', 'Set the email notification subject template. (date variable available in the template.)', 'Drill Sergeant Stale Pull Request Report (<%= date %>)')
 	.option('-l, --label', 'Should drill sergeant label the PR as stale?', false)
 	.option('-s, --staletime [number of hours]', 'Set the PR stale threshold. (default: 24)', 24)
 	.option('--include-labels [labels]', 'Define a [comma delimited] group of labels of which a PR must have at least one.', coerceList, [])
@@ -62,7 +63,7 @@ function main() {
 				return;
 			}
 			if (command.email) {
-				notifier.add(new notifiers.email(command.email, command.replyto));
+				notifier.add(new notifiers.email(command.email, command.replyto, command.subjectTemplate));
 			}
 			if (command.label) {
 				notifier.add(new notifiers.github(githubClient));

--- a/lib/notifiers/email.js
+++ b/lib/notifiers/email.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var _ = require('lodash');
 var P = require('bluebird');
 
-var Email = module.exports = function(emailAddresses, replyTo, subjectTemplate) {
+var Email = module.exports = function (emailAddresses, replyTo, subjectTemplate = 'Drill Sergeant Stale Pull Request Report (<%= date %>)') {
 	var template = fs.readFileSync(__dirname + '/../../templates/email.html').toString();
 	this.emailAddresses = emailAddresses;
 	this.replyTo = replyTo;

--- a/lib/notifiers/email.js
+++ b/lib/notifiers/email.js
@@ -2,11 +2,12 @@ var fs = require('fs');
 var _ = require('lodash');
 var P = require('bluebird');
 
-var Email = module.exports = function(emailAddresses, replyTo) {
+var Email = module.exports = function(emailAddresses, replyTo, subjectTemplate) {
 	var template = fs.readFileSync(__dirname + '/../../templates/email.html').toString();
 	this.emailAddresses = emailAddresses;
 	this.replyTo = replyTo;
 	this.compiledTemplate = _.template(template);
+	this.subjectTemplate = subjectTemplate;
 	this.client = require('nodemailer').mail;
 };
 
@@ -28,10 +29,13 @@ Email.prototype.notify = function(repos) {
 		return repo;
 	};
 	var sendEmail = function() {
+		const subject = _.template(this.subjectTemplate)({
+			date: Email.getSubjectDate()
+		});
 		return this.client({
 			from: this.replyTo,
 			to: this.emailAddresses,
-			subject: 'Drill Sergeant Stale Pull Request Report (' + Email.getSubjectDate() + ')',
+			subject: subject,
 			html: this.compiledTemplate({ repos: repos })
 		});
 	}.bind(this);

--- a/test/spec/notifiers/email.spec.js
+++ b/test/spec/notifiers/email.spec.js
@@ -6,7 +6,7 @@ describe('Email lib', function() {
 	it('will email a notification with stale repos', function() {
 		var mail, clientMock, template, repos;
 
-		mail = new email('test@test.com', 'test-from@test.com', 'Drill Sergeant Stale Pull Request Report (<%= date %>)');
+		mail = new email('test@test.com', 'test-from@test.com');
 		template = _.template(fs.readFileSync(__dirname + '/../../../templates/email.html').toString());
 		repos = [
 			{
@@ -26,6 +26,40 @@ describe('Email lib', function() {
 				from: 'test-from@test.com',
 				to: 'test@test.com',
 				subject: 'Drill Sergeant Stale Pull Request Report (2013/12/01)',
+				html: template({repos: repos})
+			});
+			expect(_.trim(options.html)).to.deep.equal(_.trim(fs.readFileSync(__dirname + '/email_output.html').toString()));
+		};
+		mail.setClient(clientMock);
+		// Mock the date on the subject
+		email.getSubjectDate = function() {
+			return '2013/12/01';
+		};
+		mail.notify(repos);
+	});
+	it('will email a notification with stale repos with customized email subject', function() {
+		var mail, clientMock, template, repos;
+
+		mail = new email('test@test.com', 'test-from@test.com', 'A customized subject (<%= date %>)');
+		template = _.template(fs.readFileSync(__dirname + '/../../../templates/email.html').toString());
+		repos = [
+			{
+				repo: 'zumba/repository',
+				prs: [{
+					created_at: new Date().toISOString(),
+					html_url: 'https://github/zumba/repository/pull/19',
+					title: 'Some <b>awesome</b> pull request',
+					user: 'someuser',
+					number: '19',
+					labels: ['sometag']
+				}]
+			}
+		];
+		clientMock = function(options) {
+			expect(options).to.deep.equal({
+				from: 'test-from@test.com',
+				to: 'test@test.com',
+				subject: 'A customized subject (2013/12/01)',
 				html: template({repos: repos})
 			});
 			expect(_.trim(options.html)).to.deep.equal(_.trim(fs.readFileSync(__dirname + '/email_output.html').toString()));

--- a/test/spec/notifiers/email.spec.js
+++ b/test/spec/notifiers/email.spec.js
@@ -1,13 +1,12 @@
 var fs = require('fs');
 var email = require('../../../lib/notifiers/email');
-var github = require('../../../lib/github');
 var _ = require('lodash');
 
 describe('Email lib', function() {
 	it('will email a notification with stale repos', function() {
 		var mail, clientMock, template, repos;
 
-		mail = new email('test@test.com', 'test-from@test.com');
+		mail = new email('test@test.com', 'test-from@test.com', 'Drill Sergeant Stale Pull Request Report (<%= date %>)');
 		template = _.template(fs.readFileSync(__dirname + '/../../../templates/email.html').toString());
 		repos = [
 			{
@@ -35,7 +34,7 @@ describe('Email lib', function() {
 		// Mock the date on the subject
 		email.getSubjectDate = function() {
 			return '2013/12/01';
-		}
+		};
 		mail.notify(repos);
 	});
 });


### PR DESCRIPTION
Adds the following option to enable customizing the subject line of the email notification:

```
drill-sergeant --subject-template="My customized subject (<%= date %>)"
```