### PR TITLE
Filter PRs in draft status

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ command
 	.option('--exclude-labels [labels]', 'Define a [comma delimited] group of labels of which a PR must NOT contain.', coerceList, [])
 	.option('--include-reviewed [count]', 'Filter PRs with at least [count] approved reviews.',  0)
 	.option('--exclude-reviewed [count]', 'Filter PRs without at least [count] approved reviews.',  0)
+	.option('--exclude-drafts', 'Should drill sergeant filter PRs in draft status?', false)
 	.option('--slack-webhook [url]', 'Slack webhook URL to post messages.')
 	.parse(process.argv);
 
@@ -54,7 +55,8 @@ async function main() {
 			.filter(filters.includeLabels.bind(null, command.includeLabels))
 			.filter(filters.excludeLabels.bind(null, command.excludeLabels))
 			.filter(repo => command.includeReviewed === 0 || filters.includeReviewed(command.includeReviewed, repo))
-			.filter(repo => command.excludeReviewed === 0 || filters.excludeReviewed(command.excludeReviewed, repo));
+			.filter(repo => command.excludeReviewed === 0 || filters.excludeReviewed(command.excludeReviewed, repo))
+			.filter(repo => !command.excludeDrafts || filters.excludeDrafts(repo));
 		if (!results.length) {
 			console.log('No stale pull requests to report.');
 			return;

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -31,5 +31,9 @@ module.exports = {
 		}
 		repo.prs = repo.prs.filter(pr => pr.reviewCount < count);
 		return repo.prs.length > 0;
+	},
+	excludeDrafts: function(repo) {
+		repo.prs = repo.prs.filter(pr => !pr.isDraft);
+		return repo.prs.length > 0;
 	}
 };

--- a/lib/githubGraph.js
+++ b/lib/githubGraph.js
@@ -13,7 +13,10 @@ const GithubGraph = class GithubGraph {
 			},
 			headers: {
 				'User-Agent': 'Drill-Sergeant-App',
-				Authorization: `bearer ${this.token}`
+				Authorization: `bearer ${this.token}`,
+				// Allows for the "preview" of draft PR properties
+				// @see https://developer.github.com/v4/previews/#draft-pull-requests-preview
+				'Accept': 'application/vnd.github.shadow-cat-preview+json',
 			},
 			json: true
 		});

--- a/lib/stalerepos.js
+++ b/lib/stalerepos.js
@@ -37,6 +37,7 @@ module.exports = class StaleRepos {
 							title: data.title,
 							number: data.number,
 							updated_at: data.updatedAt,
+							isDraft: data.isDraft,
 							labels: data.labels.edges.map(entry => entry.node.name),
 							reviewCount: data.reviews.totalCount
 						};

--- a/templates/repositoryQuery
+++ b/templates/repositoryQuery
@@ -8,6 +8,7 @@ fragment prEdge on PullRequestEdge {
     url
     number
     updatedAt
+    isDraft
     labels(first: 20) {
       edges {
         node {

--- a/test/fixture/pullrequestgraph.json
+++ b/test/fixture/pullrequestgraph.json
@@ -14,6 +14,7 @@
 							"url": "https://github.com/zumba/repository/pull/19",
 							"number": 19,
 							"updatedAt": "2013-12-04T21:44:54Z",
+							"isDraft": false,
 							"labels": {
 								"edges": [
 									{

--- a/test/fixture/pullrequestgraphquery.txt
+++ b/test/fixture/pullrequestgraphquery.txt
@@ -8,6 +8,7 @@ fragment prEdge on PullRequestEdge {
     url
     number
     updatedAt
+    isDraft
     labels(first: 20) {
       edges {
         node {

--- a/test/spec/stalerepos.spec.js
+++ b/test/spec/stalerepos.spec.js
@@ -38,6 +38,7 @@ describe('Stale Repo Lib', function() {
 						"number": 19,
 						"title": "Some pull request.",
 						"user": "cjsaylor",
+						"isDraft": false,
 						"labels": [
 							"Code Reviewed",
 							"Stale"


### PR DESCRIPTION
This PR adds an option `--exclude-drafts` to filter PRs that are in draft status.

The idea is that the draft PRs are meant for discussion and don't need to be hounded by drill-sergeant.